### PR TITLE
Add stubs for conform to the accounts.Wallet interface

### DIFF
--- a/hdwallet.go
+++ b/hdwallet.go
@@ -358,22 +358,22 @@ func (w *Wallet) Path(account accounts.Account) (string, error) {
 }
 
 // SignData is not implemented
-func (w *Wallet) SignData(account Account, mimeType string, data []byte) ([]byte, error) {
+func (w *Wallet) SignData(account accounts.Account, mimeType string, data []byte) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
 
 // SignDataWithPassphrase is not implemented
-func (w *Wallet) SignDataWithPassphrase(account Account, passphrase, mimeType string, data []byte) ([]byte, error) {
+func (w *Wallet) SignDataWithPassphrase(account accounts.Account, passphrase, mimeType string, data []byte) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
 
 // SignText is not implemented
-func (w *Wallet) SignText(account Account, text []byte) ([]byte, error) {
+func (w *Wallet) SignText(account accounts.Account, text []byte) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
 
 // SignTextWithPassphrase is not implemented
-func (w *Wallet) SignTextWithPassphrase(account Account, passphrase string, hash []byte) ([]byte, error) {
+func (w *Wallet) SignTextWithPassphrase(account accounts.Account, passphrase string, hash []byte) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/hdwallet.go
+++ b/hdwallet.go
@@ -372,6 +372,11 @@ func (w *Wallet) SignText(account Account, text []byte) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
 
+// SignTextWithPassphrase is not implemented
+func (w *Wallet) SignTextWithPassphrase(account Account, passphrase string, hash []byte) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
 // ParseDerivationPath parses the derivation path in string format into []uint32
 func ParseDerivationPath(path string) (accounts.DerivationPath, error) {
 	return accounts.ParseDerivationPath(path)

--- a/hdwallet.go
+++ b/hdwallet.go
@@ -196,7 +196,7 @@ func (w *Wallet) Derive(path accounts.DerivationPath, pin bool) (accounts.Accoun
 // user used previously (based on the chain state), but ones that he/she did not
 // explicitly pin to the wallet manually. To avoid chain head monitoring, self
 // derivation only runs during account listing (and even then throttled).
-func (w *Wallet) SelfDerive(base accounts.DerivationPath, chain ethereum.ChainStateReader) {
+func (w *Wallet) SelfDerive(base []accounts.DerivationPath, chain ethereum.ChainStateReader) {
 	// TODO: self derivation
 }
 

--- a/hdwallet.go
+++ b/hdwallet.go
@@ -357,6 +357,21 @@ func (w *Wallet) Path(account accounts.Account) (string, error) {
 	return account.URL.Path, nil
 }
 
+// SignData is not implemented
+func (w *Wallet) SignData(account Account, mimeType string, data []byte) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+// SignDataWithPassphrase is not implemented
+func (w *Wallet) SignDataWithPassphrase(account Account, passphrase, mimeType string, data []byte) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+// SignText is not implemented
+func (w *Wallet) SignText(account Account, text []byte) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
 // ParseDerivationPath parses the derivation path in string format into []uint32
 func ParseDerivationPath(path string) (accounts.DerivationPath, error) {
 	return accounts.ParseDerivationPath(path)


### PR DESCRIPTION
Obviously a temporarily solution but at least users will be able to compile. 

Note there is one breaking change with the `SelfDerive` method signature, but that method was never implemented so it should be fine.

Resolves #5 
