### PR TITLE
feat: custom signer and explicit eip 1559

### DIFF
--- a/hdwallet.go
+++ b/hdwallet.go
@@ -230,6 +230,44 @@ func (w *Wallet) SignHash(account accounts.Account, hash []byte) ([]byte, error)
 }
 
 // SignTxEIP155 implements accounts.Wallet, which allows the account to sign an ERC-20 transaction.
+func (w *Wallet) SignTxCustomSigner(account accounts.Account, tx *types.Transaction, signer types.Signer) (*types.Transaction, error) {
+	w.stateLock.RLock() // Comms have own mutex, this is for the state fields
+	defer w.stateLock.RUnlock()
+
+	// Make sure the requested account is contained within
+	path, ok := w.paths[account.Address]
+	if !ok {
+		return nil, accounts.ErrUnknownAccount
+	}
+
+	privateKey, err := w.derivePrivateKey(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sign the transaction and verify the sender to avoid hardware fault surprises
+	signedTx, err := types.SignTx(tx, signer, privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	sender, err := types.Sender(signer, signedTx)
+	if err != nil {
+		return nil, err
+	}
+
+	if sender != account.Address {
+		return nil, fmt.Errorf("signer mismatch: expected %s, got %s", account.Address.Hex(), sender.Hex())
+	}
+
+	return signedTx, nil
+}
+
+func (w *Wallet) SignTxEIP1559(account accounts.Account, tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
+	return w.SignTxCustomSigner(account, tx, types.NewLondonSigner(chainID))
+}
+
+// SignTxEIP155 implements accounts.Wallet, which allows the account to sign an ERC-20 transaction.
 func (w *Wallet) SignTxEIP155(account accounts.Account, tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
 	w.stateLock.RLock() // Comms have own mutex, this is for the state fields
 	defer w.stateLock.RUnlock()


### PR DESCRIPTION
make a more generic function that takes a custom signer 

and make `SignTxEIP1559` use the london signer which supports eip1559 dynamic fee, eip2930 access list, eip155 replay protected, and legacy homestead txns