### PR TITLE
feat: add IsMnemonicValid wrapper function

### DIFF
--- a/hdwallet.go
+++ b/hdwallet.go
@@ -491,6 +491,11 @@ func NewSeedFromMnemonic(mnemonic string, passOpt ...string) ([]byte, error) {
 	return bip39.NewSeedWithErrorChecking(mnemonic, password)
 }
 
+// IsMnemonicValid validates a mnemonic.
+func IsMnemonicValid(mnemonic string) bool {
+	return bip39.IsMnemonicValid(mnemonic)
+}
+
 // DerivePrivateKey derives the private key of the derivation path.
 func (w *Wallet) derivePrivateKey(path accounts.DerivationPath) (*ecdsa.PrivateKey, error) {
 	var err error


### PR DESCRIPTION
## Description
Add a wrapper function for `bip39.IsMnemonicValid` to maintain consistency with other BIP39-related wrapper functions in the codebase. This provides a cleaner API surface for validating mnemonics at the package level.